### PR TITLE
ignore Ctrl + Z

### DIFF
--- a/synctl/cli.py
+++ b/synctl/cli.py
@@ -3779,6 +3779,7 @@ def ctrl_exit_handler(signal_received, frame):
 def main():
     """main function"""
     signal.signal(signal.SIGINT, ctrl_exit_handler)
+    signal.signal(signal.SIGTSTP, signal.SIG_IGN)
 
     para_instanace = ParseParameter()
     para_instanace.set_options()


### PR DESCRIPTION
## Why

 when using synctl, if Ctrl + Z pressed, synctl is suspended and no result.
`zsh: suspended  synctl get test --show-result`

## What

ignore signal `SIGTSTP`