### PR TITLE
remove signal.SIGTSTP

### DIFF
--- a/synctl/cli.py
+++ b/synctl/cli.py
@@ -4801,7 +4801,6 @@ def ctrl_exit_handler(signal_received, frame):
 def main():
     """main function"""
     signal.signal(signal.SIGINT, ctrl_exit_handler)
-    signal.signal(signal.SIGTSTP, signal.SIG_IGN)
     identify_hyphen()
 
     para_instanace = ParseParameter()


### PR DESCRIPTION
# Why
synctl cannot run on Windows because SIGTSTP  is not supported in windows.

# What
Remove SIGTSTP 

# Reference
[Story](https://jsw.ibm.com/browse/INSTA-8758)