### PR TITLE
INSTA-25505-Align create custom properties format

### DIFF
--- a/synctl/cli.py
+++ b/synctl/cli.py
@@ -1201,9 +1201,9 @@ class SyntheticConfiguration(Base):
         """set active default True"""
         pass
 
-    def set_custom_properties(self, custom_prop: dict):
+    def set_custom_properties(self, custom_prop):
         """customProperties"""
-        if custom_prop is not None and isinstance(custom_prop, dict):
+        if custom_prop is not None:
             self.syn_test_config["customProperties"] = custom_prop
 
     def set_validation_string(self, validation_string):
@@ -5768,11 +5768,14 @@ def main():
                     payload.set_timeout(get_args.timeout)
 
                 if get_args.custom_properties is not None:
-                    try:
-                        payload.set_custom_properties(
-                            json.loads(get_args.custom_properties))
-                    except json.JSONDecodeError:
-                        print(payload.exit_synctl("Ensure that the JSON string is properly formatted"))
+                    split_string = get_args.custom_properties.split(',')
+                    dict_custom_properties = dict(pair.split('=') for pair in split_string)
+                    payload.set_custom_properties(dict_custom_properties)
+                    # try:
+                    #     payload.set_custom_properties(
+                    #         json.loads(get_args.custom_properties))
+                    # except json.JSONDecodeError:
+                    #     print(payload.exit_synctl("Ensure that the JSON string is properly formatted"))
 
                 # configuration
                 # retries [0, 2]


### PR DESCRIPTION
## Why
There are inconsistencies with configuring synthetic test custom-properties across create/update/patch operations.

## What 
Align create operation

## References
[Story ](https://jsw.ibm.com/browse/INSTA-25055)
[Issue](https://github.com/instana/synthetic-synctl/issues/109)