### PR TITLE
INSTA-34128: Enhance help option

### DIFF
--- a/synctl/cli.py
+++ b/synctl/cli.py
@@ -5391,10 +5391,6 @@ class ParseParameter:
         ssl_group.add_argument('--port', type=int, help='set port')
         ssl_group.add_argument('--remaining-days-check', type=int, metavar="<int>", help='check remaining days for expiration of SSL certificate')
 
-        cred_group = self.parser_create.add_argument_group("Credential Options")
-        cred_group.add_argument('--key', type=str, metavar="<key>", help='set credential name')
-        cred_group.add_argument('--value', type=str, metavar="<value>", help='set credential value')
-
         # DNS
         dns_group = self.parser_create.add_argument_group("DNS test Options")
         dns_group.add_argument('--cname', type=str, default='false', choices=['true', 'false', 'True', 'False'], metavar="<boolean>", help='enable the canonical name in the DNS response, false by default')
@@ -5419,6 +5415,11 @@ class ParseParameter:
         alert_group.add_argument('--tag-filter-expression', type=str, metavar="<json>", help="tag filter")
         alert_group.add_argument('--custom-payloads', type=str, metavar="<json>", help="Custom payload fields to send additional information in the alert notifications. Can be left empty.")
         alert_group.add_argument('--grace-period', type=str, metavar="<string>", help="The duration for which an alert remains open after conditions are no longer violated. Must range between 1 minute and a maximum of 7 days")
+
+        # cred
+        cred_group = self.parser_create.add_argument_group("Credential Options")
+        cred_group.add_argument('--key', type=str, metavar="<key>", help='set credential name')
+        cred_group.add_argument('--value', type=str, metavar="<value>", help='set credential value')
 
         # set auth
         config_group = self.parser_create.add_argument_group("Config Options")


### PR DESCRIPTION
## Why
The synctl create -h outputs a lot of very useful information but found the options section a bit confusing because there is no explicit division or differentiation about which options belong to which test type. The new DNS options added are getting printed out but unless customers are very aware that they are DNS related it will be hard or confusing to know.

## What 
Grouped according to test types
```
API Simple Options:
  --url <url>                           HTTP request URL
  --operation <method>                  HTTP request methods, GET, POST, HEAD, PUT, etc
  --follow-redirect <boolean>           to allow redirect, true by default
  --headers <json>                      HTTP headers
  --body <string>                       HTTP body
  --expect-status <int>                 Synthetic test will fail if response status is not equal to expected status code, default 200
  --expect-json <string>                An optional object to be used to check against the test response object
  --expect-match <string>               An optional regular expression string to be used to check the test response
  --expect-exists <string>              An optional list of property labels used to check if they are present in the test response object
  --expect-not-empty <string>           An optional list of property labels used to check if they are present in the test response object with a non-empty value
  --allow-insecure <boolean>            if set to true then allow insecure certificates
  --validation-string <string>          set validation-string

API Script/Browser Script Options:
  --script <file>                       load script (.js/.side) from file
  --bundle <bundle>                     Synthetic bundle test script, support zip file, zip file encoded with base64
  --bundle-entry-file <filename>        Synthetic bundle test entry file, e.g, myscript.js

Browser Script Options:
  --browser <string>                    browser type, support chrome and firefox
  --record-video <boolean>              set true to record video

SSLCertificate Options:
  --hostname <url>                      set host name
  --port PORT                           set port
  --remaining-days-check <int>          check remaining days for expiration of SSL certificate

Credential Options:
  --key <key>                           set credential name
  --value <value>                       set credential value

DNS test Options:
  --cname <boolean>                     enable the canonical name in the DNS response, false by default
  --lookup LOOKUP                       set the name or IP address of the host
  --lookup-server-name <boolean>        set recursive DNS lookups, false by default
  --query-time QUERY_TIME               an object with name/value pairs used to validate the test response time
  --query-type QUERY_TYPE               set DNS query type
  --recursive-lookups <boolean>         enables recursive DNS lookups, false by default
  --server SERVER                       set IP address of the DNS server
  --server-retries SERVER_RETRIES       set number of times to try a timed-out DNS lookup before returning failure, default is 1
  --target-values TARGET_VALUES         set list of filters to be used to validate the test response
  --transport TRANSPORT                 set protocol used to do DNS check. Only UDP is supported.

Smart Alert Options:
  --name <string>                       friendly name for smart alert
  --test <id> [<id> ...]                test id, support multiple test id
  --window-size <window>                set Synthetic result window size, support [1-60]m, [1-24]h
  --alert-channel <id> [<id> ...]       alert channel id, support multiple alert channel id
  --severity <string>                   severity of alert
  --violation-count <int>               the range is from 1 to 12 failures
  --tag-filter-expression <json>        tag filter
  --custom-payloads <json>              Custom payload fields to send additional information in the alert notifications. Can be left empty.
  --grace-period <string>               The duration for which an alert remains open after conditions are no longer violated. Must range between 1 minute and a maximum of 7 days
```



## References
[Jira Issue](https://jsw.ibm.com/browse/INSTA-34128)