### PR TITLE
INSTA-41602: Application id starting with '-' doesn't work

### DIFF
--- a/synctl/cli.py
+++ b/synctl/cli.py
@@ -4767,7 +4767,7 @@ class PatchSyntheticTest(SyntheticTest):
     def patch_application_id(self, apps):
         payload = {"configuration": {"applications": ""}}
         if apps is None or apps == "":
-            print("app id should not be none")
+            print("app id should not be empty")
         else:
             payload["applications"] = apps
             self.__patch_a_synthetic_test(self.test_id, json.dumps(payload))


### PR DESCRIPTION
## Why
1. Add patch support for applications
2. Attempting to update application IDs that begin with - results in a parsing error due to a limitation in argparse.

## What
This is a limitation of argparse, and there is no fix from their side. See https://bugs.python.org/issue9334
Workaround: Use `=` when passing arguments that start with `-`.

```synctl update test xErkE3UUGlwhmTMqmNxJ --apps=-jT48p6cR76bQR9uVahEAQ,-XMkbHp-Ql6N7vC0hvjxYA```

## References

- [Jira Issue](https://jsw.ibm.com/browse/INSTA-41602)
- [Git Issue](https://github.com/instana/synthetic-synctl/issues/120)